### PR TITLE
Fix deprication warning about using getargspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 /dist
 /docs/html
 /src/PyPubSub.egg-info
+/src/Pypubsub.egg-info
 /tools/macrium
 /tools/ping
 /docs/_build

--- a/src/pubsub/core/callables.py
+++ b/src/pubsub/core/callables.py
@@ -12,7 +12,7 @@ CallArgsInfo regarding its autoTopicArgName data member.
 
 """
 
-from inspect import getargspec, ismethod, isfunction
+from inspect import getfullargspec, ismethod, isfunction
 import sys
 from types import ModuleType
 from typing import Tuple, List, Sequence, Callable, Any
@@ -144,7 +144,7 @@ class CallArgsInfo:
             self.autoTopicArgName = None.
         """
 
-        (allParams, varParamName, varOptParamName, defaultVals) = getargspec(func)
+        (allParams, varParamName, varOptParamName, defaultVals) = getfullargspec(func)[:4]
         if defaultVals is None:
             defaultVals = []
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py33, py34, py35, py36
+envlist = py33, py34, py35, py36, py37
 toxworkdir=/.tox/pypubsub
 
 [testenv]
@@ -28,4 +28,3 @@ deps =
 deps =
     pytest
     typing
-


### PR DESCRIPTION
This will silence quite a lot of DepricationWarning messages when running pytest

https://docs.python.org/3/library/inspect.html#inspect.getargspec

```
pypubsub/src/pubsub/core/callables.py:147: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
```