### PR TITLE
Listener keyword only args

### DIFF
--- a/.idea/runConfigurations/Build_Wheel_and_Source.xml
+++ b/.idea/runConfigurations/Build_Wheel_and_Source.xml
@@ -15,6 +15,7 @@
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/setup.py" />
     <option name="PARAMETERS" value="sdist bdist_wheel" />
     <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
     <method />
   </configuration>
 </component>

--- a/.idea/runConfigurations/advanced_main.xml
+++ b/.idea/runConfigurations/advanced_main.xml
@@ -15,6 +15,7 @@
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/examples/advanced/advanced_main.py" />
     <option name="PARAMETERS" value="" />
     <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
     <method />
   </configuration>
 </component>

--- a/.idea/runConfigurations/console_main.xml
+++ b/.idea/runConfigurations/console_main.xml
@@ -15,6 +15,7 @@
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/examples/basic_kwargs/console_main.py" />
     <option name="PARAMETERS" value="" />
     <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
     <method />
   </configuration>
 </component>

--- a/.idea/runConfigurations/perf.xml
+++ b/.idea/runConfigurations/perf.xml
@@ -15,6 +15,7 @@
     <option name="SCRIPT_NAME" value="perf.py" />
     <option name="PARAMETERS" value="100000" />
     <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
     <method />
   </configuration>
 </component>

--- a/.idea/runConfigurations/py_test_in_suite.xml
+++ b/.idea/runConfigurations/py_test_in_suite.xml
@@ -22,6 +22,20 @@
     <option name="params" value="--cov=pubsub --cov-report html" />
     <option name="USE_PARAM" value="true" />
     <option name="USE_KEYWORD" value="false" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs />
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/tests/suite" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" runner="coverage.py" />
+    <option name="_new_keywords" value="&quot;&quot;" />
+    <option name="_new_additionalArguments" value="&quot;--cov\u003dpubsub --cov-report html&quot;" />
+    <option name="_new_legacyInformationCopiedToNew" value="true" />
+    <option name="_new_target" value="&quot;.&quot;" />
+    <option name="_new_targetType" value="&quot;PATH&quot;" />
     <method />
   </configuration>
 </component>

--- a/.idea/runConfigurations/wx_main.xml
+++ b/.idea/runConfigurations/wx_main.xml
@@ -15,6 +15,7 @@
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/examples/basic_kwargs/wx_main.py" />
     <option name="PARAMETERS" value="" />
     <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
     <method />
   </configuration>
 </component>

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
+  - "3.7-dev"
 
 # command to install dependencies
 install:

--- a/src/pubsub/core/topicargspec.py
+++ b/src/pubsub/core/topicargspec.py
@@ -41,7 +41,7 @@ def verifySubset(all, sub, topicName, extraMsg=''):
         raise MessageDataSpecError(msg, tuple(notInAll))
 
 
-def topicArgsFromCallable(_callable: UserListener, ignoreArgs: Seq[str] = None) -> Tuple[ArgsDocs, List[str]]:
+def topicArgsFromCallable(_callable: UserListener, ignoreArgs: Seq[str] = ()) -> Tuple[ArgsDocs, List[str]]:
     """
     Get the topic message data names and list of those that are required,
     by introspecting given callable. Returns a pair, (args, required)

--- a/tests/suite/test1_listener.py
+++ b/tests/suite/test1_listener.py
@@ -25,6 +25,22 @@ def test_ArgsInfo():
     def listener1(arg1, msgTopic = Listener.AUTO_TOPIC): pass
     CallArgsInfo(listener1)
 
+    def listenerWithHints(arg1, arg2, *, kwarg1, kwarg2=4, **kwargs): pass
+    c = CallArgsInfo(listenerWithHints)
+    assert c.acceptsAllKwargs == True
+    assert c.requiredArgs == ('arg1', 'arg2', 'kwarg1')
+    assert c.optionalArgs == ('kwarg2',)
+    assert c.getOptionalArgs() == c.optionalArgs
+    assert c.getRequiredArgs() == c.requiredArgs
+
+    def listenerWithHints2(arg1, arg2=2, *, kwarg1, kwarg2=4, **kwargs): pass
+    c = CallArgsInfo(listenerWithHints2)
+    assert c.acceptsAllKwargs == True
+    assert c.requiredArgs == ('arg1', 'kwarg1')
+    assert c.optionalArgs == ('arg2', 'kwarg2')
+    assert c.getOptionalArgs() == c.optionalArgs
+    assert c.getRequiredArgs() == c.requiredArgs
+
 
 class ArgsInfoMock:
     def __init__(self, autoTopicArgName=None):
@@ -125,7 +141,7 @@ def test_WantTopic():
     listener = MyListener()
     argsInfo = getArgs(listener.method)
     assert msgTopic == argsInfo.autoTopicArgName
-    assert ['a','b'] == argsInfo.allParams
+    assert ('a','b') == argsInfo.allParams
 
     class MyFunctor:
         def __call__(self, a, b=1, auto=Listener.AUTO_TOPIC): pass
@@ -133,7 +149,7 @@ def test_WantTopic():
     listener = MyFunctor()
     argsInfo = getArgs(listener)
     assert msgTopic == argsInfo.autoTopicArgName
-    assert ['a','b'] == argsInfo.allParams
+    assert ('a','b') == argsInfo.allParams
 
     # now some white box testing of validator that makes use of args info:
     def checkWantTopic(validate, listener, wantTopicAsArg=None):

--- a/tests/suite/test3c_pubsub3.py
+++ b/tests/suite/test3c_pubsub3.py
@@ -145,6 +145,73 @@ def testSendTopicWithMessage():
         if topic not in ('testSendTopic', 'testSendTopic.subtopic')]
 
 
+def testOptionalArgs():
+    # first function registered determines topic MDS (message data spec)
+    # here we first register a more "permissive" listener, ie one that has default values for args
+    # that the second listener does not; therefore pubsub should refuse subscribing second listener
+    # to same topic
+
+    def myFunction1(arg1, arg2=2, *, kwarg1, kwarg2=4, **kwargs): pass
+    def myFunction2(arg1, arg2,   *, kwarg1, kwarg2=4, **kwargs): pass
+
+    pub.subscribe(myFunction1, 'testKeywordOnlyArgs')
+    pytest.raises(ListenerMismatchError, pub.subscribe, myFunction2, 'testKeywordOnlyArgs')
+
+
+def testKeywordOnlyArgsStar():
+    def capture(funcName, *args):
+        result[funcName] = args
+
+    def myFunction1(arg1, arg2, *, kwarg1, kwarg2=4, **kwargs):
+        capture('myFunction1', arg1, arg2, kwarg1, kwarg2, kwargs)
+
+    def myFunction2(arg1, arg2, *arg3, kwarg1, kwarg2=4, **kwargs):
+        capture('myFunction2', arg1, arg2, arg3, kwarg1, kwarg2, kwargs)
+
+    pub.subscribe(myFunction1, 'testKeywordOnlyArgsStar')
+    pub.subscribe(myFunction2, 'testKeywordOnlyArgsStar')
+
+    result = {}
+    pub.sendMessage('testKeywordOnlyArgsStar', arg1=1, arg2=2, kwarg1=3)
+    assert result == dict(myFunction1=(1, 2, 3, 4, {}), myFunction2=(1, 2, (), 3, 4, {}))
+
+
+def testKeywordOnlyArgsStarAfterOpt():
+    def capture(funcName, *args):
+        result[funcName] = args
+
+    def myFunction1(arg1, arg2=2, *, kwarg1, kwarg2=4, **kwargs):
+        capture('myFunction1', arg1, arg2, kwarg1, kwarg2, kwargs)
+    def myFunction2(arg1, arg2=2, *arg3, kwarg1, kwarg2=4, **kwargs):
+        capture('myFunction2', arg1, arg2, arg3, kwarg1, kwarg2, kwargs)
+
+    pub.subscribe(myFunction1, 'testKeywordOnlyArgsStarAfterOpt')
+    pub.subscribe(myFunction2, 'testKeywordOnlyArgsStarAfterOpt')
+
+    result = dict()
+    pub.sendMessage('testKeywordOnlyArgsStarAfterOpt', arg1=1, kwarg1=3)
+    assert result == dict(myFunction1=(1, 2, 3, 4, {}), myFunction2=(1, 2, (), 3, 4, {}))
+
+
+def testKeywordOnlyArgsNoDefaults():
+    def capture(funcName, *args):
+        result[funcName] = args
+
+    def myFunction1(*, kwarg1, kwarg2): capture('myFunction1', kwarg1, kwarg2)
+    def myFunction2(*args, kwarg1, kwarg2): capture('myFunction2', args, kwarg1, kwarg2)
+    def myFunction3(*, kwarg1, kwarg2, **kwargs): capture('myFunction3', kwarg1, kwarg2, kwargs)
+    def myFunction4(*args, kwarg1, kwarg2, **kwargs): capture('myFunction4', args, kwarg1, kwarg2, kwargs)
+
+    pub.subscribe(myFunction1, 'testKeywordOnlyArgsNoDefaults')
+    pub.subscribe(myFunction2, 'testKeywordOnlyArgsNoDefaults')
+    pub.subscribe(myFunction3, 'testKeywordOnlyArgsNoDefaults')
+    pub.subscribe(myFunction4, 'testKeywordOnlyArgsNoDefaults')
+
+    result = {}
+    pub.sendMessage('testKeywordOnlyArgsNoDefaults', kwarg1=1, kwarg2=2)
+    assert result == dict(myFunction1=(1, 2), myFunction2=((), 1, 2), myFunction3=(1, 2, {}), myFunction4=((), 1, 2, {}))
+
+
 def testAcceptAllArgs():
     def listen(arg1=None): pass
     def listenAllArgs(arg1=None, **kwargs): pass


### PR DESCRIPTION
Indeed the fix was much simpler than expected once the transition to inspect.signature/Parameters was completed: the new inspect approach (first proposed by @skewty in #6) then allowed me in this PR to simplify CallArgsInfo considerably. Once that was done, the tests for keyword-only args passed without further modificaiton!